### PR TITLE
feature: Ingest MBTA speed restrictions to DynamoDB daily

### DIFF
--- a/ingestor/.chalice/dynamo_tables.json
+++ b/ingestor/.chalice/dynamo_tables.json
@@ -161,6 +161,33 @@
         ],
         "BillingMode": "PAY_PER_REQUEST"
       }
+    },
+    "SpeedRestrictions": {
+      "Type": "AWS::DynamoDB::Table",
+      "Properties": {
+        "TableName": "SpeedRestrictions",
+        "AttributeDefinitions": [
+          {
+            "AttributeName": "lineId",
+            "AttributeType": "S"
+          },
+          {
+            "AttributeName": "date",
+            "AttributeType": "S"
+          }
+        ],
+        "KeySchema": [
+          {
+            "AttributeName": "lineId",
+            "KeyType": "HASH"
+          },
+          {
+            "AttributeName": "date",
+            "KeyType": "RANGE"
+          }
+        ],
+        "BillingMode": "PAY_PER_REQUEST"
+      }
     }
   }
 }

--- a/ingestor/app.py
+++ b/ingestor/app.py
@@ -9,6 +9,7 @@ from chalicelib import (
     agg_speed_tables,
     gtfs,
     ridership,
+    speed_restrictions,
 )
 
 app = Chalice(app_name="ingestor")
@@ -96,6 +97,12 @@ def update_gtfs(event):
 @app.schedule(Cron(10, 7, "*", "*", "?", "*"))
 def update_ridership(event):
     ridership.ingest_ridership_data()
+
+
+# 7:20am UTC -> 2:20/3:20am ET
+@app.schedule(Cron(20, 7, "*", "*", "?", "*"))
+def update_speed_restrictions(event):
+    speed_restrictions.update_speed_restrictions()
 
 
 # Manually triggered lambda for populating monthly or weekly tables. Only needs to be ran once.

--- a/ingestor/chalicelib/gtfs/backfill/main.py
+++ b/ingestor/chalicelib/gtfs/backfill/main.py
@@ -17,8 +17,7 @@ session = boto3.Session(
 )
 
 ingest_gtfs_feeds_to_dynamo_and_s3(
-    start_date=env_start_date,
-    end_date=env_end_date,
+    date_range=(env_start_date, env_end_date),
     local_archive_path=env_local_archive_path,
     boto3_session=session,
 )

--- a/ingestor/chalicelib/speed_restrictions.py
+++ b/ingestor/chalicelib/speed_restrictions.py
@@ -1,0 +1,119 @@
+import requests
+import zipfile
+import csv
+import boto3
+from datetime import date, datetime
+from dataclasses import dataclass
+from io import BytesIO, TextIOWrapper
+from typing import Union, Tuple, List, Dict, Iterator
+
+CSV_ZIP_URL = "https://www.arcgis.com/sharing/rest/content/items/d73ed67e4cc84a84b818ea2c5caef696/data"
+
+EntryKey = Tuple[str, date]
+
+
+@dataclass
+class SpeedRestrictionEntry:
+    id: str
+    date: date
+    line_id: str
+    description: str
+    direction: str
+    reason: str
+    from_stop_id: str
+    to_stop_id: str
+    reported: date
+    speed_mph: int
+    track_feet: int
+
+    def to_json(self):
+        return {
+            "id": self.id,
+            "date": self.date.isoformat(),
+            "lineId": self.line_id,
+            "description": self.description,
+            "direction": self.direction,
+            "reason": self.reason,
+            "fromStopId": self.from_stop_id,
+            "toStopId": self.to_stop_id,
+            "reported": self.reported.isoformat(),
+            "speedMph": self.speed_mph,
+            "trackFeet": self.track_feet,
+        }
+
+    def entry_key(self) -> EntryKey:
+        return (self.line_id, self.date)
+
+
+def parse_restriction_row_to_entry(row: Dict[str, str]) -> Union[None, SpeedRestrictionEntry]:
+    try:
+        [from_stop_id, to_stop_id] = [s.strip() for s in row["Loc_GTFS_Stop_ID"].split("|")]
+    except ValueError:
+        from_stop_id = row["Loc_GTFS_Stop_ID"].strip()
+        to_stop_id = None
+    line_raw = row["Line"].replace("Line", "").strip()
+    date = datetime.strptime(row["Calendar_Date"], "%Y-%m-%d").date()
+    reported = datetime.strptime(row["Date_Restriction_Reported"], "%Y-%m-%d").date()
+    speed_mph = int(row["Restriction_Speed_MPH"].replace("mph", "").strip())
+    track_feet = int(float(row["Restriction_Distance_Feet"]))
+    status = row["Restriction_Status"].lower()
+    if "clear" in status:
+        return None
+    return SpeedRestrictionEntry(
+        id=row["ID"],
+        line_id=f"line-{line_raw}",
+        reported=reported,
+        date=date,
+        speed_mph=speed_mph,
+        track_feet=track_feet,
+        from_stop_id=from_stop_id,
+        to_stop_id=to_stop_id,
+        description=row["Location_Description"],
+        direction=row["Track_Direction"],
+        reason=row["Restriction_Reason"],
+    )
+
+
+def bucket_entries_by_key(entries: Iterator[SpeedRestrictionEntry]) -> Dict[EntryKey, List[SpeedRestrictionEntry]]:
+    buckets = {}
+    for entry in entries:
+        key = entry.entry_key()
+        if key not in buckets:
+            buckets[key] = []
+        buckets[key].append(entry)
+    return buckets
+
+
+def load_speed_restriction_entries() -> Iterator[SpeedRestrictionEntry]:
+    req = requests.get(CSV_ZIP_URL)
+    zip_file = zipfile.ZipFile(BytesIO(req.content))
+    for csv_file_name in zip_file.namelist():
+        if not csv_file_name.endswith(".csv"):
+            continue
+        csv_file = zip_file.open(csv_file_name)
+        rows = csv.DictReader(TextIOWrapper(csv_file), delimiter=",")
+        for row in rows:
+            entry = parse_restriction_row_to_entry(row)
+            if entry:
+                yield entry
+
+
+def update_speed_restrictions():
+    entries = load_speed_restriction_entries()
+    buckets = bucket_entries_by_key(entries)
+    dynamodb = boto3.resource("dynamodb")
+    SpeedRestrictions = dynamodb.Table("SpeedRestrictions")
+    with SpeedRestrictions.batch_writer() as batch:
+        for (line_id, current_date), entries in buckets.items():
+            zones = [entry.to_json() for entry in entries]
+            batch.put_item(
+                Item={
+                    "lineId": line_id,
+                    "date": current_date.isoformat(),
+                    "zones": {"zones": zones},
+                }
+            )
+
+
+if __name__ == "__main__":
+    update_speed_restrictions()


### PR DESCRIPTION
We want to ingest the MBTA's [speed restrictions data](https://www.arcgis.com/home/item.html?id=d73ed67e4cc84a84b818ea2c5caef696) into the Data Dashboard. Since I looked at this last, they changed the format quite a bit, and there's lots of data now! I've decided it might be better to store this in a database instead of a megabytes-and-growing JSON file, and so I've added a new DynamoDB table for it keyed on `(lineId, date)` and storing the associated slow zones in a `zones` JSON field. Storing this much structured data as unstructured JSON isn't ideal, but we're using Dynamo for so many other things I figured it's a quick way to get this off the ground for now. The lambda rewrites the entire table in a few seconds every day, so it's not a big deal if we want to change that schema.

_Test plan:_
```
poetry shell
python -m ingestor.chalicelib.speed_restrictions
```