### PR TITLE
feature: Merge GL trip counts into single key

### DIFF
--- a/ingestor/chalicelib/gtfs/backfill/main.py
+++ b/ingestor/chalicelib/gtfs/backfill/main.py
@@ -11,10 +11,7 @@ env_start_date = datetime.strptime(os.environ["BACKFILL_START_DATE"], "%Y-%m-%d"
 env_end_date = datetime.strptime(os.environ["BACKFILL_END_DATE"], "%Y-%m-%d").date()
 env_local_archive_path = os.environ.get("LOCAL_ARCHIVE_PATH", "./feeds")
 
-session = boto3.Session(
-    aws_access_key_id=os.environ["AWS_ACCESS_KEY_ID"],
-    aws_secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"],
-)
+session = boto3.Session()
 
 ingest_gtfs_feeds_to_dynamo_and_s3(
     date_range=(env_start_date, env_end_date),

--- a/ingestor/chalicelib/gtfs/ingest.py
+++ b/ingestor/chalicelib/gtfs/ingest.py
@@ -41,6 +41,22 @@ def load_session_models(session: Session):
     )
 
 
+def create_gl_route_date_totals(totals: List[RouteDateTotals]):
+    gl_totals = [t for t in totals if t.route_id.startswith("Green-")]
+    total_by_hour = [0] * 24
+    for total in gl_totals:
+        for i in range(24):
+            total_by_hour[i] += total.by_hour[i]
+    total_count = sum(t.count for t in gl_totals)
+    return RouteDateTotals(
+        route_id="Green",
+        line_id="Green",
+        date=totals[0].date,
+        count=total_count,
+        by_hour=total_by_hour,
+    )
+
+
 def create_route_date_totals(today: date, models: SessionModels):
     all_totals = []
     services_for_today = get_services_for_date(models, today)
@@ -56,6 +72,7 @@ def create_route_date_totals(today: date, models: SessionModels):
             by_hour=bucket_trips_by_hour(trips),
         )
         all_totals.append(totals)
+    all_totals.append(create_gl_route_date_totals(all_totals))
     return all_totals
 
 


### PR DESCRIPTION
Even though the Green Line is made of four GTFS `Routes`, we want to treat it as a single route from the perspective of parts of the Data Dashboard. This PR hacks something like that into place so we can query `TripCounts` for `routeId="Green"` and get merged totals.

I'm realizing that, long term, we may want to do this for more than just GL — the MBTA also aggregates some bus routes into lines.

_Test plan:_

Fill `ingestor/chalicelib/gtfs/backfill/.env` with some parameters:

```env
BACKFILL_START_DATE=2016-01-01
BACKFILL_END_DATE=2023-07-05
LOCAL_ARCHIVE_PATH=/path/to/a/folder/for/your/feeds
```

Then run the backfill:

```sh
poetry shell
python -m ingestor.chalicelib.gtfs.backfill.main
```