### PR TITLE
feature: Count service hours in TripCounts

### DIFF
--- a/ingestor/chalicelib/gtfs/models.py
+++ b/ingestor/chalicelib/gtfs/models.py
@@ -25,6 +25,7 @@ class RouteDateTotals:
     line_id: str
     date: date
     count: int
+    service_minutes: int
     by_hour: List[int]
 
     @property

--- a/ingestor/chalicelib/gtfs/utils.py
+++ b/ingestor/chalicelib/gtfs/utils.py
@@ -18,6 +18,10 @@ def bucket_trips_by_hour(trips: List[Trip]):
     return by_time_of_day
 
 
+def get_total_service_minutes(trips: List[Trip]):
+    return sum(trip.end_time - trip.start_time for trip in trips) // 60
+
+
 def is_valid_route_id(route_id: str):
     return (
         not route_id.startswith("Shuttle")


### PR DESCRIPTION
(Actually, service minutes)

_Test plan:_
Run the following:

```
poetry shell
python -m ingestor.chalicelib.gtfs.backfill.main
```

Verify that plausible service minute counts are appearing in the `TripCounts` table in DynamoDB