### PR TITLE
feature: Ingest more detailed trip metrics

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,5 @@
   "editor.formatOnSave": true,
   "[python]": {
     "editor.defaultFormatter": "ms-python.black-formatter"
-  },
-  "python.analysis.typeCheckingMode": "basic"
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,6 @@
   "editor.formatOnSave": true,
   "[python]": {
     "editor.defaultFormatter": "ms-python.black-formatter"
-  }
+  },
+  "python.analysis.typeCheckingMode": "basic"
 }

--- a/ingestor/.chalice/policy-delivered-trip-metrics-daily.json
+++ b/ingestor/.chalice/policy-delivered-trip-metrics-daily.json
@@ -11,10 +11,13 @@
       "Resource": "arn:*:logs:*:*:*"
     },
     {
-      "Action": ["dynamodb:BatchWriteItem"],
+      "Action": [
+        "dynamodb:BatchWriteItem"
+      ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:dynamodb:us-east-1:473352343756:table/DeliveredTripMetrics"
+        "arn:aws:dynamodb:us-east-1:473352343756:table/DeliveredTripMetrics",
+        "arn:aws:dynamodb:us-east-1:473352343756:table/DeliveredTripMetricsExtended"
       ]
     }
   ]

--- a/ingestor/.chalice/resources.json
+++ b/ingestor/.chalice/resources.json
@@ -23,9 +23,15 @@
       "Properties": {
         "Environment": {
           "Variables": {
-            "DD_API_KEY": { "Ref": "DDApiKey" },
-            "DD_VERSION": { "Ref": "GitVersion" },
-            "DD_TAGS": { "Ref": "DDTags" }
+            "DD_API_KEY": {
+              "Ref": "DDApiKey"
+            },
+            "DD_VERSION": {
+              "Ref": "GitVersion"
+            },
+            "DD_TAGS": {
+              "Ref": "DDTags"
+            }
           }
         }
       }
@@ -35,9 +41,15 @@
       "Properties": {
         "Environment": {
           "Variables": {
-            "DD_API_KEY": { "Ref": "DDApiKey" },
-            "DD_VERSION": { "Ref": "GitVersion" },
-            "DD_TAGS": { "Ref": "DDTags" }
+            "DD_API_KEY": {
+              "Ref": "DDApiKey"
+            },
+            "DD_VERSION": {
+              "Ref": "GitVersion"
+            },
+            "DD_TAGS": {
+              "Ref": "DDTags"
+            }
           }
         }
       }
@@ -47,10 +59,18 @@
       "Properties": {
         "Environment": {
           "Variables": {
-            "MBTA_V2_API_KEY": { "Ref": "MbtaV2ApiKey" },
-            "DD_API_KEY": { "Ref": "DDApiKey" },
-            "DD_VERSION": { "Ref": "GitVersion" },
-            "DD_TAGS": { "Ref": "DDTags" }
+            "MBTA_V2_API_KEY": {
+              "Ref": "MbtaV2ApiKey"
+            },
+            "DD_API_KEY": {
+              "Ref": "DDApiKey"
+            },
+            "DD_VERSION": {
+              "Ref": "GitVersion"
+            },
+            "DD_TAGS": {
+              "Ref": "DDTags"
+            }
           }
         }
       }
@@ -60,10 +80,18 @@
       "Properties": {
         "Environment": {
           "Variables": {
-            "MBTA_V2_API_KEY": { "Ref": "MbtaV2ApiKey" },
-            "DD_API_KEY": { "Ref": "DDApiKey" },
-            "DD_VERSION": { "Ref": "GitVersion" },
-            "DD_TAGS": { "Ref": "DDTags" }
+            "MBTA_V2_API_KEY": {
+              "Ref": "MbtaV2ApiKey"
+            },
+            "DD_API_KEY": {
+              "Ref": "DDApiKey"
+            },
+            "DD_VERSION": {
+              "Ref": "GitVersion"
+            },
+            "DD_TAGS": {
+              "Ref": "DDTags"
+            }
           }
         }
       }
@@ -74,9 +102,15 @@
         "Environment": {
           "Variables": {
             "DD_LAMBDA_HANDLER": "app.bb_store_station_status",
-            "DD_API_KEY": { "Ref": "DDApiKey" },
-            "DD_VERSION": { "Ref": "GitVersion" },
-            "DD_TAGS": { "Ref": "DDTags" }
+            "DD_API_KEY": {
+              "Ref": "DDApiKey"
+            },
+            "DD_VERSION": {
+              "Ref": "GitVersion"
+            },
+            "DD_TAGS": {
+              "Ref": "DDTags"
+            }
           }
         }
       }
@@ -86,9 +120,15 @@
       "Properties": {
         "Environment": {
           "Variables": {
-            "DD_API_KEY": { "Ref": "DDApiKey" },
-            "DD_VERSION": { "Ref": "GitVersion" },
-            "DD_TAGS": { "Ref": "DDTags" }
+            "DD_API_KEY": {
+              "Ref": "DDApiKey"
+            },
+            "DD_VERSION": {
+              "Ref": "GitVersion"
+            },
+            "DD_TAGS": {
+              "Ref": "DDTags"
+            }
           }
         }
       }
@@ -98,9 +138,15 @@
       "Properties": {
         "Environment": {
           "Variables": {
-            "DD_API_KEY": { "Ref": "DDApiKey" },
-            "DD_VERSION": { "Ref": "GitVersion" },
-            "DD_TAGS": { "Ref": "DDTags" }
+            "DD_API_KEY": {
+              "Ref": "DDApiKey"
+            },
+            "DD_VERSION": {
+              "Ref": "GitVersion"
+            },
+            "DD_TAGS": {
+              "Ref": "DDTags"
+            }
           }
         }
       }
@@ -111,9 +157,15 @@
         "Environment": {
           "Variables": {
             "DD_LAMBDA_HANDLER": "app.update_delivered_trip_metrics",
-            "DD_API_KEY": { "Ref": "DDApiKey" },
-            "DD_VERSION": { "Ref": "GitVersion" },
-            "DD_TAGS": { "Ref": "DDTags" }
+            "DD_API_KEY": {
+              "Ref": "DDApiKey"
+            },
+            "DD_VERSION": {
+              "Ref": "GitVersion"
+            },
+            "DD_TAGS": {
+              "Ref": "DDTags"
+            }
           }
         }
       }
@@ -123,9 +175,15 @@
       "Properties": {
         "Environment": {
           "Variables": {
-            "DD_API_KEY": { "Ref": "DDApiKey" },
-            "DD_VERSION": { "Ref": "GitVersion" },
-            "DD_TAGS": { "Ref": "DDTags" }
+            "DD_API_KEY": {
+              "Ref": "DDApiKey"
+            },
+            "DD_VERSION": {
+              "Ref": "GitVersion"
+            },
+            "DD_TAGS": {
+              "Ref": "DDTags"
+            }
           }
         }
       }
@@ -135,9 +193,15 @@
       "Properties": {
         "Environment": {
           "Variables": {
-            "DD_API_KEY": { "Ref": "DDApiKey" },
-            "DD_VERSION": { "Ref": "GitVersion" },
-            "DD_TAGS": { "Ref": "DDTags" }
+            "DD_API_KEY": {
+              "Ref": "DDApiKey"
+            },
+            "DD_VERSION": {
+              "Ref": "GitVersion"
+            },
+            "DD_TAGS": {
+              "Ref": "DDTags"
+            }
           }
         }
       }
@@ -147,9 +211,15 @@
       "Properties": {
         "Environment": {
           "Variables": {
-            "DD_API_KEY": { "Ref": "DDApiKey" },
-            "DD_VERSION": { "Ref": "GitVersion" },
-            "DD_TAGS": { "Ref": "DDTags" }
+            "DD_API_KEY": {
+              "Ref": "DDApiKey"
+            },
+            "DD_VERSION": {
+              "Ref": "GitVersion"
+            },
+            "DD_TAGS": {
+              "Ref": "DDTags"
+            }
           }
         }
       }
@@ -159,9 +229,15 @@
       "Properties": {
         "Environment": {
           "Variables": {
-            "DD_API_KEY": { "Ref": "DDApiKey" },
-            "DD_VERSION": { "Ref": "GitVersion" },
-            "DD_TAGS": { "Ref": "DDTags" }
+            "DD_API_KEY": {
+              "Ref": "DDApiKey"
+            },
+            "DD_VERSION": {
+              "Ref": "GitVersion"
+            },
+            "DD_TAGS": {
+              "Ref": "DDTags"
+            }
           }
         }
       }
@@ -171,9 +247,15 @@
       "Properties": {
         "Environment": {
           "Variables": {
-            "DD_API_KEY": { "Ref": "DDApiKey" },
-            "DD_VERSION": { "Ref": "GitVersion" },
-            "DD_TAGS": { "Ref": "DDTags" }
+            "DD_API_KEY": {
+              "Ref": "DDApiKey"
+            },
+            "DD_VERSION": {
+              "Ref": "GitVersion"
+            },
+            "DD_TAGS": {
+              "Ref": "DDTags"
+            }
           }
         }
       }
@@ -183,9 +265,15 @@
       "Properties": {
         "Environment": {
           "Variables": {
-            "DD_API_KEY": { "Ref": "DDApiKey" },
-            "DD_VERSION": { "Ref": "GitVersion" },
-            "DD_TAGS": { "Ref": "DDTags" }
+            "DD_API_KEY": {
+              "Ref": "DDApiKey"
+            },
+            "DD_VERSION": {
+              "Ref": "GitVersion"
+            },
+            "DD_TAGS": {
+              "Ref": "DDTags"
+            }
           }
         }
       }
@@ -195,9 +283,15 @@
       "Properties": {
         "Environment": {
           "Variables": {
-            "DD_API_KEY": { "Ref": "DDApiKey" },
-            "DD_VERSION": { "Ref": "GitVersion" },
-            "DD_TAGS": { "Ref": "DDTags" }
+            "DD_API_KEY": {
+              "Ref": "DDApiKey"
+            },
+            "DD_VERSION": {
+              "Ref": "GitVersion"
+            },
+            "DD_TAGS": {
+              "Ref": "DDTags"
+            }
           }
         }
       }
@@ -216,7 +310,33 @@
             "KeyType": "RANGE"
           }
         ],
-
+        "AttributeDefinitions": [
+          {
+            "AttributeName": "route",
+            "AttributeType": "S"
+          },
+          {
+            "AttributeName": "date",
+            "AttributeType": "S"
+          }
+        ],
+        "BillingMode": "PAY_PER_REQUEST"
+      }
+    },
+    "DeliveredTripMetricsExtendedDB": {
+      "Type": "AWS::DynamoDB::Table",
+      "Properties": {
+        "TableName": "DeliveredTripMetricsExtended",
+        "KeySchema": [
+          {
+            "AttributeName": "route",
+            "KeyType": "HASH"
+          },
+          {
+            "AttributeName": "date",
+            "KeyType": "RANGE"
+          }
+        ],
         "AttributeDefinitions": [
           {
             "AttributeName": "route",
@@ -244,7 +364,6 @@
             "KeyType": "RANGE"
           }
         ],
-
         "AttributeDefinitions": [
           {
             "AttributeName": "line",
@@ -272,7 +391,6 @@
             "KeyType": "RANGE"
           }
         ],
-
         "AttributeDefinitions": [
           {
             "AttributeName": "line",

--- a/ingestor/app.py
+++ b/ingestor/app.py
@@ -14,6 +14,7 @@ from chalicelib import (
     speed_restrictions,
     predictions,
     landing,
+    trip_metrics,
 )
 
 app = Chalice(app_name="ingestor")
@@ -115,6 +116,12 @@ def update_speed_restrictions(event):
 @app.schedule(Cron(30, 7, "*", "*", "?", "*"))
 def update_time_predictions(event):
     predictions.update_predictions()
+
+
+# 4:40am UTC -> 2:40/3:40am ET every day
+@app.schedule(Cron(40, 7, "*", "*", "?", "*"))
+def update_trip_metrics(event):
+    trip_metrics.ingest_trip_metrics_yesterday()
 
 
 # Manually triggered lambda for populating daily trip metric tables. Only needs to be ran once.

--- a/ingestor/chalicelib/constants.py
+++ b/ingestor/chalicelib/constants.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 from decimal import Decimal
-from chalicelib import stations
+from . import stations
 
 ALL_ROUTES = [
     ["line-red", "a"],
@@ -19,127 +19,226 @@ TERMINI_NEW = {
         "a": {
             "line": "line-red",
             "route": "a",
-            "stops": [
-                [STATIONS["SHAWMUT"]["NB"], STATIONS["DAVIS"]["NB"]],
-                [STATIONS["DAVIS"]["SB"], STATIONS["SHAWMUT"]["SB"]],
-            ],
-            "length": Decimal("20.26"),
+            "excluding_terminals": {
+                "stops": [
+                    [STATIONS["SHAWMUT"]["NB"], STATIONS["DAVIS"]["NB"]],
+                    [STATIONS["DAVIS"]["SB"], STATIONS["SHAWMUT"]["SB"]],
+                ],
+                "length": Decimal("20.26"),
+            },
+            "including_terminals": {
+                "stops": [
+                    [STATIONS["ASHMONT"]["NB"], STATIONS["ALEWIFE"]["NB"]],
+                    [STATIONS["ALEWIFE"]["SB"], STATIONS["ASHMONT"]["SB"]],
+                ],
+            },
         },
         "b": {
             "line": "line-red",
             "route": "b",
-            "stops": [
-                [STATIONS["QUINCY_ADAMS"]["NB"], STATIONS["DAVIS"]["NB"]],
-                [STATIONS["DAVIS"]["SB"], STATIONS["QUINCY_ADAMS"]["SB"]],
-            ],
-            "length": Decimal("29.64"),
+            "excluding_terminals": {
+                "stops": [
+                    [STATIONS["QUINCY_ADAMS"]["NB"], STATIONS["DAVIS"]["NB"]],
+                    [STATIONS["DAVIS"]["SB"], STATIONS["QUINCY_ADAMS"]["SB"]],
+                ],
+                "length": Decimal("29.64"),
+            },
+            "including_terminals": {
+                "stops": [
+                    [STATIONS["BRAINTREE"]["NB"], STATIONS["ALEWIFE"]["NB"]],
+                    [STATIONS["ALEWIFE"]["SB"], STATIONS["BRAINTREE"]["SB"]],
+                ],
+            },
         },
     },
     "line-orange": {
         "line": "line-orange",
         "route": None,
-        "stops": [
-            [STATIONS["GREEN_STREET"]["NB"], STATIONS["MALDEN_CENTER"]["NB"]],
-            [STATIONS["MALDEN_CENTER"]["SB"], STATIONS["GREEN_STREET"]["SB"]],
-        ],
-        "length": Decimal("19.22"),
+        "excluding_terminals": {
+            "stops": [
+                [STATIONS["GREEN_STREET"]["NB"], STATIONS["MALDEN_CENTER"]["NB"]],
+                [STATIONS["MALDEN_CENTER"]["SB"], STATIONS["GREEN_STREET"]["SB"]],
+            ],
+            "length": Decimal("19.22"),
+        },
+        "including_terminals": {
+            "stops": [
+                [STATIONS["FOREST_HILLS"]["NB"], STATIONS["OAK_GROVE"]["NB"]],
+                [STATIONS["OAK_GROVE"]["SB"], STATIONS["FOREST_HILLS"]["SB"]],
+            ],
+        },
     },
     "line-blue": {
         "line": "line-blue",
         "route": None,
-        "stops": [
-            [STATIONS["GOV_CENTER_BLUE"]["NB"], STATIONS["REVERE_BEACH"]["NB"]],
-            [STATIONS["REVERE_BEACH"]["SB"], STATIONS["GOV_CENTER_BLUE"]["SB"]],
-        ],
-        "length": Decimal("10.75"),
+        "excluding_terminals": {
+            "stops": [
+                [STATIONS["GOV_CENTER_BLUE"]["NB"], STATIONS["REVERE_BEACH"]["NB"]],
+                [STATIONS["REVERE_BEACH"]["SB"], STATIONS["GOV_CENTER_BLUE"]["SB"]],
+            ],
+            "length": Decimal("10.75"),
+        },
+        "including_terminals": {
+            "stops": [
+                [STATIONS["BOWDOIN"]["NB"], STATIONS["WONDERLAND"]["NB"]],
+                [STATIONS["WONDERLAND"]["SB"], STATIONS["BOWDOIN"]["SB"]],
+            ],
+        },
     },
     "line-green-post-glx": {
         "b": {
             "line": "line-green",
             "route": "b",
-            "stops": [
-                [STATIONS["SOUTH_ST"]["NB"], STATIONS["BOYLSTON"]["NB"]],
-                [STATIONS["BOYLSTON"]["SB"], STATIONS["SOUTH_ST"]["SB"]],
-            ],
-            "length": Decimal("5.39") * 2,
+            "excluding_terminals": {
+                "stops": [
+                    [STATIONS["SOUTH_ST"]["NB"], STATIONS["BOYLSTON"]["NB"]],
+                    [STATIONS["BOYLSTON"]["SB"], STATIONS["SOUTH_ST"]["SB"]],
+                ],
+                "length": Decimal("5.39") * 2,
+            },
+            "including_terminals": {
+                "stops": [
+                    [STATIONS["BOSTON_COLLEGE"]["NB"], STATIONS["GOV_CENTER_GREEN"]["NB"]],
+                    [STATIONS["GOV_CENTER_GREEN"]["SB"], STATIONS["BOSTON_COLLEGE"]["SB"]],
+                ]
+            },
         },
         "c": {
             "line": "line-green",
             "route": "c",
-            "stops": [
-                [STATIONS["ENGLEWOOD"]["NB"], STATIONS["GOV_CENTER_GREEN"]["NB"]],
-                [STATIONS["GOV_CENTER_GREEN"]["SB"], STATIONS["ENGLEWOOD"]["SB"]],
-            ],
-            "length": Decimal("4.91") * 2,
+            "excluding_terminals": {
+                "stops": [
+                    [STATIONS["ENGLEWOOD"]["NB"], STATIONS["GOV_CENTER_GREEN"]["NB"]],
+                    [STATIONS["GOV_CENTER_GREEN"]["SB"], STATIONS["ENGLEWOOD"]["SB"]],
+                ],
+                "length": Decimal("4.91") * 2,
+            },
+            "including_terminals": {
+                "stops": [
+                    [STATIONS["CLEVELAND_CIRCLE"]["NB"], STATIONS["GOV_CENTER_GREEN"]["NB"]],
+                    [STATIONS["GOV_CENTER_GREEN"]["SB"], STATIONS["CLEVELAND_CIRCLE"]["SB"]],
+                ]
+            },
         },
         "d": {
             "line": "line-green",
             "route": "d",
-            "stops": [
-                [STATIONS["WOODLAND"]["NB"], STATIONS["LECHMERE"]["NB"]],
-                [STATIONS["LECHMERE"]["SB"], STATIONS["WOODLAND"]["SB"]],
-            ],
-            "length": Decimal("12.81") * 2,
+            "excluding_terminals": {
+                "stops": [
+                    [STATIONS["WOODLAND"]["NB"], STATIONS["LECHMERE"]["NB"]],
+                    [STATIONS["LECHMERE"]["SB"], STATIONS["WOODLAND"]["SB"]],
+                ],
+                "length": Decimal("12.81") * 2,
+            },
+            "including_terminals": {
+                "stops": [
+                    [STATIONS["RIVERSIDE"]["NB"], STATIONS["UNION_SQUARE"]["NB"]],
+                    [STATIONS["UNION_SQUARE"]["SB"], STATIONS["RIVERSIDE"]["SB"]],
+                ]
+            },
         },
         "e": {
             "line": "line-green",
             "route": "e",
-            "stops": [
-                [STATIONS["BACK_OF_THE_HILL"]["NB"], STATIONS["BALL_SQ"]["NB"]],
-                [STATIONS["BALL_SQ"]["SB"], STATIONS["BACK_OF_THE_HILL"]["SB"]],
-            ],
-            "length": Decimal("7.88") * 2,
+            "excluding_terminals": {
+                "stops": [
+                    [STATIONS["BACK_OF_THE_HILL"]["NB"], STATIONS["BALL_SQ"]["NB"]],
+                    [STATIONS["BALL_SQ"]["SB"], STATIONS["BACK_OF_THE_HILL"]["SB"]],
+                ],
+                "length": Decimal("7.88") * 2,
+            },
+            "including_terminals": {
+                "stops": [
+                    [STATIONS["HEATH_ST"]["NB"], STATIONS["MEDFORD_TUFTS"]["NB"]],
+                    [STATIONS["MEDFORD_TUFTS"]["SB"], STATIONS["HEATH_ST"]["SB"]],
+                ]
+            },
         },
     },
     "line-green-pre-glx": {
         "b": {
             "line": "line-green",
             "route": "b",
-            "stops": [
-                [STATIONS["SOUTH_ST"]["NB"], STATIONS["BOYLSTON"]["NB"]],
-                [STATIONS["BOYLSTON"]["SB"], STATIONS["SOUTH_ST"]["SB"]],
-            ],
-            "length": Decimal("5.39") * 2,
+            "excluding_terminals": {
+                "stops": [
+                    [STATIONS["SOUTH_ST"]["NB"], STATIONS["BOYLSTON"]["NB"]],
+                    [STATIONS["BOYLSTON"]["SB"], STATIONS["SOUTH_ST"]["SB"]],
+                ],
+                "length": Decimal("5.39") * 2,
+            },
+            "including_terminals": {
+                "stops": [
+                    [STATIONS["BOSTON_COLLEGE"]["NB"], STATIONS["PARK_ST"]["NB"]],
+                    [STATIONS["PARK_ST"]["SB"], STATIONS["BOSTON_COLLEGE"]["SB"]],
+                ]
+            },
         },
         "c": {
             "line": "line-green",
             "route": "c",
-            "stops": [
-                [STATIONS["ENGLEWOOD"]["NB"], STATIONS["GOV_CENTER_GREEN"]["NB"]],
-                [STATIONS["GOV_CENTER_GREEN"]["SB"], STATIONS["ENGLEWOOD"]["SB"]],
-            ],
-            "length": Decimal("4.91") * 2,
+            "excluding_terminals": {
+                "stops": [
+                    [STATIONS["ENGLEWOOD"]["NB"], STATIONS["GOV_CENTER_GREEN"]["NB"]],
+                    [STATIONS["GOV_CENTER_GREEN"]["SB"], STATIONS["ENGLEWOOD"]["SB"]],
+                ],
+                "length": Decimal("4.91") * 2,
+            },
+            "including_terminals": {
+                "stops": [
+                    [STATIONS["CLEVELAND_CIRCLE"]["NB"], STATIONS["GOV_CENTER_GREEN"]["NB"]],
+                    [STATIONS["NORTH_STATION_GREEN"]["SB"], STATIONS["NORTH_STATION_GREEN"]["SB"]],
+                ]
+            },
         },
         "d": {
             "line": "line-green",
             "route": "d",
-            "stops": [
-                [STATIONS["WOODLAND"]["NB"], STATIONS["PARK_ST"]["NB"]],
-                [STATIONS["PARK_ST"]["SB"], STATIONS["WOODLAND"]["SB"]],
-            ],
-            "length": Decimal("11.06") * 2,
+            "excluding_terminals": {
+                "stops": [
+                    # Not sure if Park was always the terminus but it is reliable
+                    [STATIONS["WOODLAND"]["NB"], STATIONS["PARK_ST"]["NB"]],
+                    [STATIONS["PARK_ST"]["SB"], STATIONS["WOODLAND"]["SB"]],
+                ],
+                "length": Decimal("11.06") * 2,
+            },
+            "including_terminals": {
+                "stops": [
+                    [STATIONS["RIVERSIDE"]["NB"], STATIONS["PARK_ST"]["NB"]],
+                    [STATIONS["PARK_ST"]["SB"], STATIONS["RIVERSIDE"]["SB"]],
+                ]
+            },
         },
         "e": {
             "line": "line-green",
             "route": "e",
-            "stops": [
-                [STATIONS["BACK_OF_THE_HILL"]["NB"], STATIONS["GOV_CENTER_GREEN"]["NB"]],
-                [STATIONS["GOV_CENTER_GREEN"]["SB"], STATIONS["BACK_OF_THE_HILL"]["SB"]],
-            ],
-            "length": Decimal("3.73") * 2,
+            "excluding_terminals": {
+                "stops": [
+                    # Not sure if Park was always the terminus but it is reliable
+                    [STATIONS["BACK_OF_THE_HILL"]["NB"], STATIONS["GOV_CENTER_GREEN"]["NB"]],
+                    [STATIONS["GOV_CENTER_GREEN"]["SB"], STATIONS["BACK_OF_THE_HILL"]["SB"]],
+                ],
+                "length": Decimal("3.73") * 2,
+            },
+            "including_terminals": {
+                "stops": [
+                    [STATIONS["HEATH_ST"]["NB"], STATIONS["GOV_CENTER_GREEN"]["NB"]],
+                    [STATIONS["GOV_CENTER_GREEN"]["SB"], STATIONS["HEATH_ST"]["SB"]],
+                ]
+            },
         },
     },
 }
 
 
-def get_route_metadata(line, date, route=None):
+def get_route_metadata(line, date, include_terminals, route=None):
+    terminals_key = "including_terminals" if include_terminals else "excluding_terminals"
     if line == "line-green":
         if date < GLX_EXTENSION_DATE:
-            return TERMINI_NEW[f"{line}-pre-glx"][route]
-        return TERMINI_NEW[f"{line}-post-glx"][route]
+            return TERMINI_NEW[f"{line}-pre-glx"][route][terminals_key]
+        return TERMINI_NEW[f"{line}-post-glx"][route][terminals_key]
     if route:
-        return TERMINI_NEW[line][route]
-    return TERMINI_NEW[line]
+        return TERMINI_NEW[line][route][terminals_key]
+    return TERMINI_NEW[line][terminals_key]
 
 
 LINES = ["line-red", "line-orange", "line-blue", "line-green"]
@@ -151,7 +250,7 @@ RIDERSHIP_KEYS = {
 }
 DATE_FORMAT = "%Y-%m-%dT%H:%M:%S"
 DATE_FORMAT_BACKEND = "%Y-%m-%d"
-GLX_EXTENSION_DATE = datetime.strptime("2023-03-19", DATE_FORMAT_BACKEND)
+GLX_EXTENSION_DATE = datetime.strptime("2023-03-19", DATE_FORMAT_BACKEND).date()
 TODAY = datetime.now().date()
 
 ONE_WEEK_AGO_STRING = (TODAY - timedelta(weeks=1)).strftime(DATE_FORMAT_BACKEND)

--- a/ingestor/chalicelib/daily_speeds.py
+++ b/ingestor/chalicelib/daily_speeds.py
@@ -99,7 +99,7 @@ def populate_daily_table(start_date, end_date, line, route):
     delta = timedelta(days=180)
     speed_objects = []
     while current_date < end_date:
-        route_metadata = constants.get_route_metadata(line, current_date, route)
+        route_metadata = constants.get_route_metadata(line, current_date, False, route)
         print(f"Calculating daily values for 180 day chunk starting at: {current_date}")
         API_requests = get_agg_tt_api_requests(route_metadata["stops"], current_date, delta)
         curr_speed_object = send_requests(API_requests)
@@ -124,7 +124,7 @@ def update_daily_table(date):
     """Update DailySpeed table"""
     speed_objects = []
     for route in constants.ALL_ROUTES:
-        route_metadata = constants.get_route_metadata(route[0], date, route[1])
+        route_metadata = constants.get_route_metadata(route[0], date, False, route[1])
         delta = timedelta(days=1)
         date_string = datetime.strftime(date, constants.DATE_FORMAT_BACKEND)
         print(f"Calculating update on [{route[0]}/{route[1] if route[1] else '(no-route)'}] for date: {date_string}")

--- a/ingestor/chalicelib/stations.py
+++ b/ingestor/chalicelib/stations.py
@@ -1,5 +1,17 @@
 STATIONS = {
     # RED LINE
+    "ALEWIFE": {
+        "SB": 70061,
+        "NB": 70061,
+    },
+    "ASHMONT": {
+        "SB": 70093,
+        "NB": 70094,
+    },
+    "BRAINTREE": {
+        "SB": 70105,
+        "NB": 70105,
+    },
     "DAVIS": {
         "SB": 70063,
         "NB": 70064,
@@ -21,6 +33,14 @@ STATIONS = {
         "SB": 70002,
         "NB": 70003,
     },
+    "FOREST_HILLS": {
+        "SB": 70001,
+        "NB": 70001,
+    },
+    "OAK_GROVE": {
+        "SB": 70036,
+        "NB": 70036,
+    },
     # BLUE LINE
     "REVERE_BEACH": {
         "SB": 70057,
@@ -30,7 +50,39 @@ STATIONS = {
         "SB": 70039,
         "NB": 70040,
     },
+    "WONDERLAND": {
+        "SB": 70059,
+        "NB": 70060,
+    },
+    "BOWDOIN": {
+        "SB": 70838,
+        "NB": 70038,
+    },
     # GREEN LINE
+    "BOSTON_COLLEGE": {
+        "SB": 70106,
+        "NB": 70107,
+    },
+    "CLEVELAND_CIRCLE": {
+        "SB": 70238,
+        "NB": 70237,
+    },
+    "RIVERSIDE": {
+        "SB": 70160,
+        "NB": 70161,
+    },
+    "HEATH_ST": {
+        "SB": 70260,
+        "NB": 70260,
+    },
+    "MEDFORD_TUFTS": {
+        "SB": 70511,
+        "NB": 70512,
+    },
+    "UNION_SQUARE": {
+        "SB": 70503,
+        "NB": 70504,
+    },
     "SOUTH_ST": {
         "SB": 70111,
         "NB": 70110,
@@ -46,6 +98,10 @@ STATIONS = {
     "GOV_CENTER_GREEN": {
         "SB": 70202,
         "NB": 70201,
+    },
+    "NORTH_STATION_GREEN": {
+        "SB": 70205,
+        "NB": 70206,
     },
     "WOODLAND": {
         "SB": 70163,
@@ -64,7 +120,7 @@ STATIONS = {
         "NB": 70509,
     },
     "PARK_ST": {
-        "SB": [70196, 70197, 70198, 70199],
+        "SB": (70196, 70197, 70198, 70199),
         "NB": 70200,
     },
 }

--- a/ingestor/chalicelib/trip_metrics/__init__.py
+++ b/ingestor/chalicelib/trip_metrics/__init__.py
@@ -1,0 +1,3 @@
+__all__ = ["ingest_trip_metrics_yesterday", "ingest_trip_metrics"]
+
+from .ingest import ingest_trip_metrics_yesterday, ingest_trip_metrics

--- a/ingestor/chalicelib/trip_metrics/backfill.py
+++ b/ingestor/chalicelib/trip_metrics/backfill.py
@@ -1,0 +1,14 @@
+from datetime import date
+from tqdm import tqdm
+
+from .ingest import ingest_trip_metrics, get_date_ranges
+
+START_DATE = date(2023, 8, 29)
+END_DATE = date(2023, 8, 30)
+MAX_RANGE_SIZE = 90
+
+if __name__ == "__main__":
+    date_ranges = get_date_ranges(START_DATE, END_DATE, MAX_RANGE_SIZE)
+    for start_date, end_date in (progress := tqdm(date_ranges)):
+        progress.set_description(f"{start_date} to {end_date}...")
+        ingest_trip_metrics(start_date, end_date)

--- a/ingestor/chalicelib/trip_metrics/ingest.py
+++ b/ingestor/chalicelib/trip_metrics/ingest.py
@@ -1,0 +1,185 @@
+import requests
+import json
+import pandas as pd
+from datetime import timedelta, date, datetime
+from decimal import Decimal
+from urllib.parse import urlencode
+from typing import List
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+
+from .. import constants
+from .. import dynamo
+from .types import AggTravelTimesRequest, AggTravelTimesResponse, PeakType, DirectionType
+
+KEYS_TO_KEEP = ["25%", "50%", "75%", "count", "max", "mean", "min", "std"]
+
+
+def create_dataframe(dicts) -> pd.DataFrame:
+    return pd.DataFrame(
+        dicts,
+        {
+            "25%": int,
+            "50%": int,
+            "75%": int,
+            "count": int,
+            "max": int,
+            "mean": float,
+            "min": int,
+            "std": float,
+            "peak": PeakType,
+            "service_date": str,
+            "from_stop": str,
+            "to_stop": str,
+            "route_id": str,
+            "direction": DirectionType,
+            "includes_terminals": bool,
+        },
+    )
+
+
+def request_agg_travel_time(request: AggTravelTimesRequest) -> AggTravelTimesResponse:
+    params = {
+        "from_stop": request.stop_pair[0],
+        "to_stop": request.stop_pair[1],
+        "start_date": date.strftime(request.start_date, constants.DATE_FORMAT_BACKEND),
+        "end_date": date.strftime(request.end_date, constants.DATE_FORMAT_BACKEND),
+    }
+    request_url = constants.DD_URL_AGG_TT.format(parameters=urlencode(params, doseq=True))
+    response = requests.get(request_url)
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError:
+        print(response.content.decode("utf-8"))
+        raise
+    return json.loads(response.content.decode("utf-8"))
+
+
+def get_date_ranges(start_date: date, end_date: date, max_range_size: int, breakpoint_dates: List[date] = []):
+    naive_ranges = []
+    current_date = start_date
+    while current_date < end_date:
+        next_date = current_date + timedelta(days=max_range_size)
+        if next_date > end_date:
+            next_date = end_date
+        naive_ranges.append((current_date, next_date))
+        current_date = next_date
+    ranges = []
+    for start, end in naive_ranges:
+        breakpoint_dates_in_range = [d for d in breakpoint_dates if start <= d < end]
+        boundaries = [start, *breakpoint_dates_in_range, end]
+        for i in range(len(boundaries) - 1):
+            ranges.append((boundaries[i], boundaries[i + 1]))
+    return [
+        (start, end - timedelta(days=1)) if idx != len(ranges) - 1 else (start, end)
+        for idx, (start, end) in enumerate(ranges)
+    ]
+
+
+def generate_requests(
+    start_date: date,
+    end_date: date,
+    max_date_range_size: int = 50,
+) -> List[AggTravelTimesRequest]:
+    reqs = []
+    date_ranges = get_date_ranges(start_date, end_date, max_date_range_size, [constants.GLX_EXTENSION_DATE])
+    for start_date, end_date in date_ranges:
+        for line, route in constants.ALL_ROUTES:
+            if line.startswith("line-green"):
+                continue
+            for includes_terminals in (True, False):
+                route_metadata = constants.get_route_metadata(line, start_date, includes_terminals, route)
+                stop_pairs = route_metadata["stops"]
+                for direction in ("0", "1"):
+                    request = AggTravelTimesRequest(
+                        route_id=f"{line}-{route}" if route else line,
+                        includes_terminals=includes_terminals,
+                        direction=direction,
+                        stop_pair=tuple(stop_pairs[0 if direction == "0" else 1]),
+                        start_date=start_date,
+                        end_date=end_date,
+                    )
+                    reqs.append(request)
+    return reqs
+
+
+def load_travel_time_dataframe(
+    start_date: date,
+    end_date: date,
+) -> pd.DataFrame:
+    reqs = generate_requests(start_date, end_date)
+    df_dicts = []
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        futures = {executor.submit(request_agg_travel_time, req): req for req in reqs}
+        for future in as_completed(futures):
+            result = future.result()
+            key = futures[future]
+            for by_date_entry in result:
+                df_dicts.append(
+                    {
+                        **by_date_entry,
+                        "from_stop": key.stop_pair[0],
+                        "to_stop": key.stop_pair[1],
+                        "route_id": key.route_id,
+                        "direction": key.direction,
+                        "includes_terminals": key.includes_terminals,
+                    }
+                )
+    return pd.DataFrame(df_dicts)
+
+
+def get_df_entry_for_direction_and_exclusivity(df: pd.DataFrame, direction: DirectionType, includes_terminals: bool):
+    entry = df[(df["direction"] == direction) & (df["includes_terminals"] == includes_terminals)]
+    prefix = f"dir_{direction}_{'inclusive' if includes_terminals else 'exclusive'}"
+    if entry.empty:
+        # Sometimes we don't have any data including terminals for a given date
+        return None
+    assert len(entry) == 1
+    return {f"{prefix}_{key}": value for key, value in entry.iloc[0].to_dict().items() if key in KEYS_TO_KEEP}
+
+
+def prepare_dict_for_dynamo(row_dict):
+    res = {}
+    for key, value in row_dict.items():
+        if isinstance(value, float):
+            res[key] = Decimal(str(round(value, 2)))
+        elif isinstance(value, int):
+            res[key] = Decimal(value)
+        else:
+            res[key] = value
+    return res
+
+
+def ingest_trip_metrics(start_date: date, end_date: date):
+    df = load_travel_time_dataframe(start_date, end_date)
+    df = df[df["peak"] == "all"]
+    # get all dates
+    dates = df["service_date"].unique()
+    route_ids = df["route_id"].unique()
+    row_dicts = []
+    for route_id in route_ids:
+        for date_str in sorted(dates):
+            date_data = df[(df["service_date"] == date_str) & (df["route_id"] == route_id)]
+            sb_exclusive = get_df_entry_for_direction_and_exclusivity(date_data, "0", False)
+            nb_exclusive = get_df_entry_for_direction_and_exclusivity(date_data, "1", False)
+            sb_inclusive = get_df_entry_for_direction_and_exclusivity(date_data, "0", True)
+            nb_inclusive = get_df_entry_for_direction_and_exclusivity(date_data, "1", True)
+            if sb_exclusive and nb_exclusive and sb_inclusive and nb_inclusive:
+                row_dict = prepare_dict_for_dynamo(
+                    {
+                        "date": date_str,
+                        "route": route_id,
+                        **sb_exclusive,
+                        **nb_exclusive,
+                        **sb_inclusive,
+                        **nb_inclusive,
+                    }
+                )
+                row_dicts.append(row_dict)
+    dynamo.dynamo_batch_write(row_dicts, "DeliveredTripMetricsExtended")
+
+
+def ingest_trip_metrics_yesterday():
+    today = date.today()
+    yesterday = today - timedelta(days=1)
+    ingest_trip_metrics(yesterday, today)

--- a/ingestor/chalicelib/trip_metrics/ingest.py
+++ b/ingestor/chalicelib/trip_metrics/ingest.py
@@ -1,7 +1,7 @@
 import requests
 import json
 import pandas as pd
-from datetime import timedelta, date, datetime
+from datetime import timedelta, date
 from decimal import Decimal
 from urllib.parse import urlencode
 from typing import List

--- a/ingestor/chalicelib/trip_metrics/types.py
+++ b/ingestor/chalicelib/trip_metrics/types.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass
+from typing import Tuple, TypedDict, Literal, List
+from datetime import date
+
+StopPair = Tuple[str, str]
+PeakType = Literal["all", "off_peak", "am_peak", "pm_peak"]
+DirectionType = Literal["0", "1"]
+
+
+@dataclass(frozen=True, eq=True)
+class AggTravelTimesRequest(object):
+    route_id: str
+    includes_terminals: bool
+    direction: Literal["0", "1"]
+    stop_pair: StopPair
+    start_date: date
+    end_date: date
+
+
+class AggTravelTimesByDateEntry(TypedDict):
+    count: int
+    max: int
+    mean: float
+    min: int
+    std: float
+    peak: PeakType
+    service_date: str
+
+
+AggTravelTimesResponse = List[AggTravelTimesByDateEntry]

--- a/poetry.lock
+++ b/poetry.lock
@@ -1381,6 +1381,26 @@ files = [
 ]
 
 [[package]]
+name = "tqdm"
+version = "4.66.1"
+description = "Fast, Extensible Progress Meter"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "tqdm-4.66.1-py3-none-any.whl", hash = "sha256:d302b3c5b53d47bce91fea46679d9c3c6508cf6332229aa1e7d8653723793386"},
+    {file = "tqdm-4.66.1.tar.gz", hash = "sha256:d88e651f9db8d8551a62556d3cff9e3034274ca5d66e93197cf2490e2dcb69c7"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+dev = ["pytest (>=6)", "pytest-cov", "pytest-timeout", "pytest-xdist"]
+notebook = ["ipywidgets (>=6)"]
+slack = ["slack-sdk"]
+telegram = ["requests"]
+
+[[package]]
 name = "typing-extensions"
 version = "4.7.1"
 description = "Backported and Experimental Type Hints for Python 3.7+"
@@ -1545,4 +1565,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.10, <3.11"
-content-hash = "eb82c3f2362d3ee1630928ee238c224b713c6b03ce2c40b7a7d62dfe5b1cfc29"
+content-hash = "457a01be46863b5420c1d0a6afb557857f55126a10271f90c802d66f9c0f0708"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ openpyxl = "^3.1.2"
 dynamodb-json = "^1.3"
 datadog_lambda = "4.77.0"
 ddtrace = "1.15.2"
+tqdm = "^4.66.1"
 
 [tool.poetry.dev-dependencies]
 chalice = "^1.29.0"


### PR DESCRIPTION
This PR adds a `DeliveredTripMetricsExtended` table which will give us good estimates of total delivered service hours. Like `DeliveredTripMetrics`, it stores data from `/api/aggregate/traveltimes2` to get a per-line, per-day snapshot of end-to-end travel time performance. Unlike that table it:

- Separately tracks travel time by direction of travel (`0`, `1`)
- Stores values for trips that are `inclusive` of terminals (Alewife->Ashmont) and `exclusive` of them (Davis->Shawmut)

In other words, every day we'll query these trips as a snapshot `line-red-a`:

- Alewife->Ashmont `(0, inclusive)`
- Ashmont->Alewife `(1, inclusive)`
- Davis->Shawmut `(0, exclusive)`
- Shawmut->Davis `(1, exclusive)`

Since we're storing all the provided statistics for all of these trips (count, mean, std, quartiles) it adds up to quite a few columns!

## Calculating "delivered service hours"

My original goal was a reliable estimate of how many total hours of service each line gets each day (especially as compared to the promises set out by GTFS). I ran into a series of problems as I tried to do this:

- Terminal segments — those directly preceding (Shawmut->Ashmont) or following (Alewife->Davis) a terminal — are known to be noisy. The Performance API has a process to cull outliers from that data, often removing 50% or more of the day's trips.
- As a result, we ignore it in our speed metric calculations, which was the original impetus for `DeliveredTripMetrics`. This makes speed more accurate, but it means the `total_time` field on that table is a considerable under-count.
- So if we include terminal segments, we get low `n`, but if we exclude them, we undercount trip hours.

The solution is just to take

```
total_time = n_southbound_excl * t_southbound_incl + n_northbound_excl * t_northbound_incl
```

In other words, for each direction, we use the mean of available _inclusive_ travel times and multiply that with the more reliable count of _exclusive_ end-end trips. ([See a spreadsheet of one day's calculations done by hand.](https://docs.google.com/spreadsheets/d/1Ii5VDEmetByJmPwU0QvmgrDn_k4CEipfoAUwI3Dl7O0/edit#gid=0)) Because the trends and the `delivered / scheduled` fractions closely track what we see when counting trips, I feel confident that this is a reliable metric of service quality — and one that's more robust to shuttling than trip counts!

I still have to add tables for weekly and monthly delivered service hours — but I want to get this in here now.

_Trip counts vs. service hours (new) in the DD:_
![image](https://github.com/transitmatters/data-ingestion/assets/2208769/698a9eaa-7418-4c4c-860b-8b09ab24517b)
