### PR TITLE
Fixing date comparisons

### DIFF
--- a/ingestor/chalicelib/constants.py
+++ b/ingestor/chalicelib/constants.py
@@ -1,16 +1,16 @@
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from decimal import Decimal
 from . import stations
 
-ALL_ROUTES = [
-    ["line-red", "a"],
-    ["line-red", "b"],
-    ["line-orange", None],
-    ["line-blue", None],
-    ["line-green", "b"],
-    ["line-green", "c"],
-    ["line-green", "d"],
-    ["line-green", "e"],
+ALL_ROUTES: list[tuple[str, str | None]] = [
+    ("line-red", "a"),
+    ("line-red", "b"),
+    ("line-orange", None),
+    ("line-blue", None),
+    ("line-green", "b"),
+    ("line-green", "c"),
+    ("line-green", "d"),
+    ("line-green", "e"),
 ]
 STATIONS = stations.STATIONS
 
@@ -230,7 +230,7 @@ TERMINI_NEW = {
 }
 
 
-def get_route_metadata(line, date, include_terminals, route=None):
+def get_route_metadata(line: str, date: date, include_terminals: bool, route: str | None = None):
     terminals_key = "including_terminals" if include_terminals else "excluding_terminals"
     if line == "line-green":
         if date < GLX_EXTENSION_DATE:
@@ -241,7 +241,7 @@ def get_route_metadata(line, date, include_terminals, route=None):
     return TERMINI_NEW[line][terminals_key]
 
 
-LINES = ["line-red", "line-orange", "line-blue", "line-green"]
+LINES: list[str] = ["line-red", "line-orange", "line-blue", "line-green"]
 RIDERSHIP_KEYS = {
     "line-red": "line-Red",
     "line-orange": "line-Orange",

--- a/ingestor/chalicelib/daily_speeds.py
+++ b/ingestor/chalicelib/daily_speeds.py
@@ -1,4 +1,4 @@
-from datetime import timedelta, datetime
+from datetime import date, timedelta, datetime
 from decimal import Decimal
 import json
 from urllib.parse import urlencode
@@ -56,7 +56,9 @@ def send_requests(api_requests):
     return speed_object
 
 
-def format_tt_objects(speed_objects, route_metadata, line, route, expected_num_entries, date_range):
+def format_tt_objects(
+    speed_objects, route_metadata, line: str, route: str | None, expected_num_entries, date_range: list[str]
+):
     """Remove invalid entries and format for Dynamo."""
     formatted_speed_objects = []
     route_name = f"{line}-{route}"
@@ -82,8 +84,8 @@ def format_tt_objects(speed_objects, route_metadata, line, route, expected_num_e
     return formatted_speed_objects
 
 
-def get_date_range_strings(start_date, end_date):
-    date_range = []
+def get_date_range_strings(start_date: date, end_date: date):
+    date_range: list[str] = []
     current_date = start_date
     while current_date <= end_date:
         date_range.append(current_date.strftime("%Y-%m-%d"))
@@ -91,10 +93,10 @@ def get_date_range_strings(start_date, end_date):
     return date_range
 
 
-def populate_daily_table(start_date, end_date, line, route):
+def populate_daily_table(start_date: datetime, end_date: datetime, line: str, route: str | None):
     """Populate DeliveredTripMetrics table. Calculates median TTs and trip counts for all days between start and end dates."""
     print(f"populating DeliveredTripMetrics for Line/Route: {line}/{route if route else '(no-route)'}")
-    current_date = start_date
+    current_date = start_date.date()
     delta = timedelta(days=180)
     speed_objects = []
     while current_date < end_date:


### PR DESCRIPTION
Fixing https://app.datadoghq.com/apm/error-tracking/issue/be77ad6e-b48b-11ee-ad0d-da7ad0900002?query=env%3Aprod%20service%3Aingestor&refresh_mode=sliding&view=spans&from_ts=1705421607834&to_ts=1705422492193&live=true

We were trying to compare datetime with date

Now resolving this issue and adding type hints to make sure this is more likely avoided in the future