### PR TITLE
fix(yankee): fix the cloudformation for yankee lambda

### DIFF
--- a/ingestor/.chalice/config.json
+++ b/ingestor/.chalice/config.json
@@ -101,7 +101,7 @@
           "iam_policy_file": "policy-time-predictions.json",
           "lambda_timeout": 300
         },
-        "yankee": {
+        "update_yankee_shuttles": {
           "iam_policy_file": "policy-yankee.json",
           "lambda_timeout": 900
         }

--- a/ingestor/.chalice/resources.json
+++ b/ingestor/.chalice/resources.json
@@ -6,8 +6,8 @@
     },
     "YankeeApiKey": {
       "Type": "String",
-      "Description", "Yankee shuttle API key"
-    }
+      "Description": "Yankee shuttle API key"
+    },
     "DDApiKey": {
       "Type": "String",
       "Description": "Datadog API key."

--- a/ingestor/app.py
+++ b/ingestor/app.py
@@ -159,5 +159,5 @@ def store_landing_data(event):
 
 # Runs every 5 minutes from either 4 AM -> 1:55AM or 5 AM -> 2:55 AM depending on DST
 @app.schedule(Cron("0/5", "0-6,9-23", "*", "*", "?", "*"))
-def update_yankee_shuttle_bucket(event):
+def update_yankee_shuttles(event):
     yankee.update_shuttles()


### PR DESCRIPTION
I didn't realize that the name in `config.json` for chalice had to match up with the name of the lambda, and the error message the package gave wasn't super helpful 😅 