### PR TITLE
fix(yankee): remove unnecessary yankee function resource

### DIFF
--- a/ingestor/.chalice/resources.json
+++ b/ingestor/.chalice/resources.json
@@ -40,27 +40,6 @@
         }
       }
     },
-    "Yankee": {
-      "Type": "AWS::Serverless::Function",
-      "Properties": {
-        "Environment": {
-          "Variables": {
-            "DD_API_KEY": {
-              "Ref": "DDApiKey"
-            },
-            "DD_VERSION": {
-              "Ref": "GitVersion"
-            },
-            "DD_TAGS": {
-              "Ref": "DDTags"
-            },
-            "YANKEE_API_KEY": {
-              "Ref": "YankeeApiKey"
-            }
-          }
-        }
-      }
-    },
     "PopulateAggDeliveredTripMetrics": {
       "Type": "AWS::Serverless::Function",
       "Properties": {


### PR DESCRIPTION
Apparently adding a resource for my lambda to `resources.json` wasnt necessary. I'm guessing the lambdas that are in there are only there to account for what we created before we started using CloudFormation? Anyway, here's the diff between the manual resource and what chalice is creating.


```
    "UpdateYankeeShuttles": {
      "Type": "AWS::Serverless::Function",
      "Properties": {
        "Runtime": "python3.11",
        "Handler": "app.update_yankee_shuttles",
        "CodeUri": "./deployment.zip",
        "Tags": {
          "service": "ingestor",
          "env": "prod",
          "aws-chalice": "version=1.31.0:stage=prod:app=ingestor"
        },
        "Tracing": "PassThrough",
        "Timeout": 900,
        "MemorySize": 128,
        "Environment": {
          "Variables": {
            "DD_SITE": "datadoghq.com",
            "DD_ENV": "prod",
            "DD_SERVICE": "ingestor",
            "DD_TRACE_ENABLED": "true"
          }
        },
        "Role": {
          "Fn::GetAtt": [
            "UpdateYankeeShuttlesRole",
            "Arn"
          ]
        },
        "Events": {
          "UpdateYankeeShuttlesEvent": {
            "Type": "Schedule",
            "Properties": {
              "Schedule": "cron(0/5 0-6,9-23 * * ? *)"
            }
          }
        }
      }
    },
    "Yankee": {
      "Type": "AWS::Serverless::Function",
      "Properties": {
        "Environment": {
          "Variables": {
            "DD_API_KEY": {
              "Ref": "DDApiKey"
            },
            "DD_VERSION": {
              "Ref": "GitVersion"
            },
            "DD_TAGS": {
              "Ref": "DDTags"
            },
            "YANKEE_API_KEY": {
              "Ref": "YankeeApiKey"
            }
          }
        }
      }
    },
```

Notice that first one is missing handler and runtime, which is the error we saw on the last deploy