### PR TITLE
fix(yankee): Improve timeouts by never locally building GTFS SQLite db

### DIFF
--- a/ingestor/chalicelib/yankee.py
+++ b/ingestor/chalicelib/yankee.py
@@ -234,8 +234,8 @@ def _update_shuttles(last_bus_positions: List[Dict], shuttle_shapes: ShapeDict, 
         raise Exception(f"Received status code {response.status_code} from Samsara bus API. Body: {response.text}")
     try:
         buses = json.loads(response.text)["data"]
-    except:
-        raise Exception(f"Bus response did not contain data. Instead received {json}")
+    except Exception:
+        raise Exception(f"Bus response problematic. We received {json}")
 
     print(buses)
     bus_positions = []


### PR DESCRIPTION
Previously the lambda was taking >900s to run. This is likely because it was building a GTFS SQLite db locally everytime, since there was a GTFS feed that hadn't been ingested by our GTFS lambda and added to the `tm-gtfs` S3 bucket. This change should force the yankee lambda to never build the SQLite db locally