### PR TITLE
Adding commuter rail ridership to the landing page

### DIFF
--- a/ingestor/chalicelib/constants.py
+++ b/ingestor/chalicelib/constants.py
@@ -248,6 +248,21 @@ RIDERSHIP_KEYS = {
     "line-blue": "line-Blue",
     "line-green": "line-Green",
 }
+COMMUTER_RAIL_LINES = [
+    "CR-Fairmount",
+    "CR-Fitchburg",
+    "CR-Worcester",
+    "CR-Franklin",
+    "CR-Greenbush",
+    "CR-Haverhill",
+    "CR-Kingston",
+    "CR-Lowell",
+    "CR-Middleborough",
+    "CR-Needham",
+    "CR-Newburyport",
+    "CR-Providence",
+]
+
 DATE_FORMAT = "%Y-%m-%dT%H:%M:%S"
 DATE_FORMAT_BACKEND = "%Y-%m-%d"
 GLX_EXTENSION_DATE = datetime.strptime("2023-03-19", DATE_FORMAT_BACKEND).date()
@@ -259,6 +274,10 @@ NINETY_DAYS_AGO_STRING = (TODAY - timedelta(days=90)).strftime(DATE_FORMAT_BACKE
 
 DD_URL_AGG_TT = "https://dashboard-api.labs.transitmatters.org/api/aggregate/traveltimes?{parameters}"
 DD_URL_SINGLE_TT = "https://dashboard-api.labs.transitmatters.org/api/traveltimes/{date}?{parameters}"
+
+
+def commuter_rail_ridership_key(line: str):
+    return f"line-{line[3:]}"
 
 
 def get_monthly_table_update_start():

--- a/ingestor/chalicelib/landing.py
+++ b/ingestor/chalicelib/landing.py
@@ -44,6 +44,7 @@ def get_ridership_data():
         data = query_landing_ridership_data(constants.RIDERSHIP_KEYS[line])
         ridership_object[line] = data
 
+    # get data for commuter rail (treated as one line)
     ridership_object["line-commuter-rail"] = [None] * 10
     for line in constants.COMMUTER_RAIL_LINES:
         data = query_landing_ridership_data(constants.commuter_rail_ridership_key(line))
@@ -59,6 +60,8 @@ def get_ridership_data():
                     "date": week["date"],
                 }
                 ridership_object["line-commuter-rail"][index] = data
+    # filter out None values
+    ridership_object["line-commuter-rail"] = [x for x in ridership_object["line-commuter-rail"] if x is not None]
 
     return ridership_object
 

--- a/ingestor/chalicelib/landing.py
+++ b/ingestor/chalicelib/landing.py
@@ -43,6 +43,23 @@ def get_ridership_data():
     for line in constants.LINES:
         data = query_landing_ridership_data(constants.RIDERSHIP_KEYS[line])
         ridership_object[line] = data
+
+    ridership_object["line-commuter-rail"] = [None] * 10
+    for line in constants.COMMUTER_RAIL_LINES:
+        data = query_landing_ridership_data(constants.commuter_rail_ridership_key(line))
+        for index, week in enumerate(data):
+            if ridership_object["line-commuter-rail"][index] is None:
+                ridership_object["line-commuter-rail"][index] = week
+                continue
+            else:
+                data = {
+                    "lineId": "line-commuter-rail",
+                    "count": ridership_object["line-commuter-rail"][index]["count"] + week["count"],
+                    "timestamp": week["timestamp"],
+                    "date": week["date"],
+                }
+                ridership_object["line-commuter-rail"][index] = data
+
     return ridership_object
 
 


### PR DESCRIPTION
After we can merge https://github.com/transitmatters/t-performance-dash/pull/1001 we should have ridership data ready to go on the landing page

<img width="507" alt="Screenshot 2024-07-25 at 8 20 17 PM" src="https://github.com/user-attachments/assets/00f535d8-b438-4041-9d6a-966922796818">
