### PR TITLE
Update ridership cache

### DIFF
--- a/ingestor/chalicelib/bluebikes.py
+++ b/ingestor/chalicelib/bluebikes.py
@@ -162,9 +162,14 @@ def calc_daily_stats(day):
 
     # create fields to determine rideability
     df["pct_full"] = df["num_bikes_available"] / (df["num_docks_available"] + df["num_bikes_available"])
-    df["rideable"] = np.where(
-        (df["pct_full"] >= 0.1) & (df["pct_full"] <= 0.85) & (df["station_status"] == "active"), 1, 0
-    )
+
+    # station_status seems to be missing from recent data, is_renting is present and may be the equivalent
+    if "station_status" in df.columns:
+        df["rideable"] = np.where(
+            (df["pct_full"] >= 0.1) & (df["pct_full"] <= 0.85) & (df["station_status"] == "active"), 1, 0
+        )
+    elif "is_renting" in df.columns:
+        df["rideable"] = np.where((df["pct_full"] >= 0.1) & (df["pct_full"] <= 0.85) & (df["is_renting"] == 1), 1, 0)
 
     # create data frames on rideability for station and neighbors
     df_sm = df[["station_id", "pct_full", "rideable", "datetimepulled"]]

--- a/ingestor/chalicelib/ridership/arcgis.py
+++ b/ingestor/chalicelib/ridership/arcgis.py
@@ -1,0 +1,14 @@
+import requests
+
+from .config import (
+    CR_UPDATE_CACHE_URL,
+)
+
+
+def cr_update_cache():
+    """
+    This function is used to update the cache for the CR ridership data
+    on the ArcGIS Hub. This is necessary because the data is large enough
+    where the cache isn't updated automatically.
+    """
+    requests.get(CR_UPDATE_CACHE_URL)

--- a/ingestor/chalicelib/ridership/backfill/manual.py
+++ b/ingestor/chalicelib/ridership/backfill/manual.py
@@ -1,0 +1,29 @@
+from ...ridership.dynamo import ingest_ridership_to_dynamo
+from ...ridership.ingest import get_ridership_by_line_id
+from ...ridership.process import get_ridership_by_route_id
+from ...ridership.gtfs import get_routes_by_line_id
+import argparse
+
+
+"""
+For when we need to backfill ridership data with manual file paths.
+
+Example usage:
+
+python -m chalicelib.ridership.backfill.manual --subway-file /path/to/subway/file --bus-file /path/to/bus/file --cr-file /path/to/cr/file
+
+"""
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Backfill ridership data with manual file paths")
+    parser.add_argument("--subway-file", required=False, help="Path to subway ridership file")
+    parser.add_argument("--bus-file", required=False, help="Path to bus ridership file")
+    parser.add_argument("--cr-file", required=False, help="Path to commuter rail ridership file")
+
+    args = parser.parse_args()
+
+    routes = get_routes_by_line_id()
+
+    ridership_by_route_id = get_ridership_by_route_id(args.subway_file, args.bus_file, args.cr_file)
+    ridership_by_line_id = get_ridership_by_line_id(ridership_by_route_id, routes)
+    ingest_ridership_to_dynamo(ridership_by_line_id)

--- a/ingestor/chalicelib/ridership/config.py
+++ b/ingestor/chalicelib/ridership/config.py
@@ -7,3 +7,5 @@ RIDERSHIP_BUS_XLSX_REGEX = re.compile(r"Weekly_Bus_Ridership_by_Route_(\d{4})\.(
 RIDERSHIP_SUBWAY_CSV_REGEX = re.compile(r"(\d{4})\.(\d{1,2})\.(\d{1,2}) MBTA Gated Station Validations by line", re.I)
 
 CR_RIDERSHIP_ARCGIS_URL = "https://opendata.arcgis.com/api/v3/datasets/e2635c945f5b47a7923e0ee441b040c8_0/downloads/data?format=csv&spatialRefId=4326&where=1=1"
+
+CR_UPDATE_CACHE_URL = "https://hub.arcgis.com/api/download/v1/items/e2635c945f5b47a7923e0ee441b040c8/csv?redirect=false&layers=0&updateCache=true"

--- a/ingestor/chalicelib/ridership/ingest.py
+++ b/ingestor/chalicelib/ridership/ingest.py
@@ -3,6 +3,7 @@ from mbta_gtfs_sqlite.models import Route
 
 from ..gtfs.utils import bucket_by
 from .box import download_latest_ridership_files
+from .arcgis import cr_update_cache
 from .dynamo import ingest_ridership_to_dynamo
 from .gtfs import get_routes_by_line_id
 from .process import get_ridership_by_route_id
@@ -29,6 +30,7 @@ def get_ridership_by_line_id(
 
 def ingest_ridership_data():
     routes = get_routes_by_line_id()
+    cr_update_cache()
     subway_file, bus_file, cr_file = download_latest_ridership_files()
     ridership_by_route_id = get_ridership_by_route_id(subway_file, bus_file, cr_file)
     ridership_by_line_id = get_ridership_by_line_id(ridership_by_route_id, routes)

--- a/ingestor/chalicelib/ridership/process.py
+++ b/ingestor/chalicelib/ridership/process.py
@@ -188,8 +188,10 @@ def format_cr_data(path_to_ridershp_file: str):
     return ridership_by_route
 
 
-def get_ridership_by_route_id(path_to_subway_file: str, path_to_bus_file: str, path_to_cr_file: str):
-    subway = format_subway_data(path_to_subway_file)
-    bus = format_bus_data(path_to_bus_file)
-    cr = format_cr_data(path_to_cr_file)
+def get_ridership_by_route_id(
+    path_to_subway_file: str | None, path_to_bus_file: str | None, path_to_cr_file: str | None
+):
+    subway = format_subway_data(path_to_subway_file) if path_to_subway_file else {}
+    bus = format_bus_data(path_to_bus_file) if path_to_bus_file else {}
+    cr = format_cr_data(path_to_cr_file) if path_to_cr_file else {}
     return {**subway, **bus, **cr}


### PR DESCRIPTION
The ridership data from ARCGIS requires an update the cache periodically. We should send the cache request before we process it, so that we don't need any manual intervention going forward