### PR TITLE
Fix GTFS processing for when big changes occur

### DIFF
--- a/ingestor/.chalice/config.json
+++ b/ingestor/.chalice/config.json
@@ -91,9 +91,16 @@
         },
         "update_gtfs": {
           "iam_policy_file": "policy-gtfs.json",
-          "lambda_timeout": 500,
+          "lambda_timeout": 300,
           "lambda_memory_size": 768,
           "max_ebs_size_gb": 4
+        },
+        "backfill_gtfs": {
+          "iam_policy_file": "policy-gtfs.json",
+          "lambda_timeout": 500,
+          "lambda_memory_size": 4096,
+          "max_ebs_size_gb": 4,
+          "log_retention_in_days": 15
         },
         "update_ridership": {
           "iam_policy_file": "policy-ridership.json",

--- a/ingestor/.chalice/config.json
+++ b/ingestor/.chalice/config.json
@@ -92,7 +92,7 @@
         "update_gtfs": {
           "iam_policy_file": "policy-gtfs.json",
           "lambda_timeout": 300,
-          "lambda_memory_size": 768,
+          "lambda_memory_size": 1024,
           "max_ebs_size_gb": 4
         },
         "backfill_gtfs": {

--- a/ingestor/.chalice/resources.json
+++ b/ingestor/.chalice/resources.json
@@ -261,6 +261,30 @@
           }
         },
         "EphemeralStorage": {
+          "Size": 1024
+        }
+      }
+    },
+    "BackfillGtfs": {
+      "Type": "AWS::Serverless::Function",
+      "Properties": {
+        "Environment": {
+          "Variables": {
+            "DD_API_KEY": {
+              "Ref": "DDApiKey"
+            },
+            "DD_VERSION": {
+              "Ref": "GitVersion"
+            },
+            "DD_TAGS": {
+              "Ref": "DDTags"
+            },
+            "DD_GIT_REPOSITORY_URL": {
+              "Ref": "DDGitRepositoryUrl"
+            }
+          }
+        },
+        "EphemeralStorage": {
           "Size": 2048
         }
       }

--- a/ingestor/app.py
+++ b/ingestor/app.py
@@ -111,8 +111,16 @@ def update_time_predictions(event):
 @app.schedule(Cron(0, 8, "*", "*", "?", "*"))
 def update_gtfs(event):
     today = datetime.now()
-    last_week = (today - timedelta(days=7)).date()
-    gtfs.ingest_gtfs_feeds_to_dynamo_and_s3(date_range=(last_week, today.date()))
+    two_days_ago = (today - timedelta(days=2)).date()
+    gtfs.ingest_gtfs_feeds_to_dynamo_and_s3(date_range=(two_days_ago, today.date()))
+
+
+# 8:30am UTC -> 3:30/4:30am ET every Monday
+@app.schedule(Cron(30, 8, "?", "*", "MON", "*"))
+def backfill_gtfs(event):
+    today = datetime.now()
+    two_weeks_ago = (today - timedelta(days=14)).date()
+    gtfs.ingest_gtfs_feeds_to_dynamo_and_s3(date_range=(two_weeks_ago, today.date()))
 
 
 # 4:40am UTC -> 2:40/3:40am ET every day


### PR DESCRIPTION
Right now we process GTFS daily, however when big changes happen, we end up needing to run manual updates

We don't have enough memory for that in the daily job and it runs out of memory to finish processing

It does however have enough to process a normal week. We then should backfill once a week in a bigger job that can handle these issues so at worst we fall behind by 1 week