### PR TITLE
Add service/ridership stats by mode

### DIFF
--- a/ingestor/chalicelib/service_ridership_dashboard/ingest.py
+++ b/ingestor/chalicelib/service_ridership_dashboard/ingest.py
@@ -15,7 +15,7 @@ from .ridership import RidershipEntry, ridership_by_line_id
 from .s3 import put_dashboard_json_to_s3
 from .service_levels import ServiceLevelsByDate, ServiceLevelsEntry, get_service_level_entries_by_line_id
 from .service_summaries import summarize_weekly_service_around_date
-from .summary import get_summary_data
+from .summary import get_summary_data, get_summary_data_by_mode
 from .time_series import get_weekly_median_time_series
 from .types import DashJSON, LineData, LineKind, ServiceRegimes
 from .util import date_from_string, date_to_string
@@ -171,8 +171,14 @@ def create_service_ridership_dash_json(
         start_date=start_date,
         end_date=end_date,
     )
+    mode_data = get_summary_data_by_mode(
+        line_data=list(line_data_by_line_id.values()),
+        start_date=start_date,
+        end_date=end_date,
+    )
     dash_json: DashJSON = {
         "summaryData": summary_data,
+        "modeData": mode_data,
         "lineData": line_data_by_line_id,
     }
     if write_debug_files:

--- a/ingestor/chalicelib/service_ridership_dashboard/summary.py
+++ b/ingestor/chalicelib/service_ridership_dashboard/summary.py
@@ -4,8 +4,8 @@ from .time_series import (
     get_latest_weekly_median_time_series_entry,
     merge_weekly_median_time_series,
 )
-from .types import LineData, SummaryData
-from .util import date_to_string
+from .types import LineData, ModeKind, SummaryData
+from .util import bucket_by, date_to_string, line_kind_to_mode_kind
 
 
 def _line_is_cancelled(line: LineData) -> bool:
@@ -91,3 +91,15 @@ def get_summary_data(line_data: list[LineData], start_date: date, end_date: date
         "startDate": date_to_string(start_date),
         "endDate": date_to_string(end_date),
     }
+
+
+def get_summary_data_by_mode(
+    line_data: list[LineData],
+    start_date: date,
+    end_date: date,
+) -> dict[ModeKind, SummaryData]:
+    lines_by_mode = bucket_by(line_data, lambda line: line_kind_to_mode_kind(line["lineKind"]))
+    mode_summary_data: dict[ModeKind, SummaryData] = {}
+    for mode, lines in lines_by_mode.items():
+        mode_summary_data[mode] = get_summary_data(lines, start_date, end_date)
+    return mode_summary_data

--- a/ingestor/chalicelib/service_ridership_dashboard/types.py
+++ b/ingestor/chalicelib/service_ridership_dashboard/types.py
@@ -11,6 +11,21 @@ LineKind = Literal[
     "boat",
 ]
 
+
+MODE_KINDS = [
+    "rapid-transit",
+    "regional-rail",
+    "bus",
+    "boat",
+]
+
+ModeKind = Literal[
+    "rapid-transit",
+    "regional-rail",
+    "bus",
+    "boat",
+]
+
 WeeklyMedianTimeSeries = dict[str, float]  # Map yyyy-mm-dd to numbers
 
 
@@ -61,3 +76,4 @@ class SummaryData(TypedDict):
 class DashJSON(TypedDict):
     lineData: dict[str, LineData]
     summaryData: SummaryData
+    modeData: dict[ModeKind, SummaryData]

--- a/ingestor/chalicelib/service_ridership_dashboard/util.py
+++ b/ingestor/chalicelib/service_ridership_dashboard/util.py
@@ -1,5 +1,7 @@
 from datetime import date, datetime, timedelta
-from typing import Tuple
+from typing import Optional, Tuple
+
+from .types import LineKind, ModeKind
 
 
 def date_from_string(date_str):
@@ -67,3 +69,15 @@ def date_range_contains(containing: Tuple[date, date], contained: Tuple[date, da
     (containing_from, containing_to) = containing
     (contained_from, contained_to) = contained
     return contained_from >= containing_from and contained_to <= containing_to
+
+
+def line_kind_to_mode_kind(line_kind: LineKind) -> Optional[ModeKind]:
+    if line_kind == "bus":
+        return "bus"
+    if line_kind == "regional-rail":
+        return "regional-rail"
+    if line_kind == "boat":
+        return "boat"
+    if line_kind in ("red", "orange", "blue", "green", "silver"):
+        return "rapid-transit"
+    return None


### PR DESCRIPTION
## Motivation

Companion PR for https://github.com/transitmatters/t-performance-dash/pull/1141

## Changes

Adds new `modeData` key to service/ridership data with `SummaryData` shape but broken down by mode

## Testing Instructions

Run:
```
poetry run python -m ingestor.chalicelib.service_ridership_dashboard.ingest --debug
```
Then inspect `service_ridership_dashboard/dash.json`
